### PR TITLE
Use counter instead of random name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,11 @@ var util  = require('util')
 var stuff = require('./utils')
 
 /**
+ * Counter for multi usage.
+ */
+var counter = 0;
+
+/**
  * Expose `Plugin`
  */
 
@@ -44,7 +49,8 @@ function Plugin(regexp, replacer) {
 
   // this plugin can be inserted multiple times,
   // so we're generating unique name for it
-  self.id = 'regexp-' + String(Math.random).slice(2)
+  self.id = 'regexp-' + counter;
+  counter++;
 
   return self
 }


### PR DESCRIPTION
Plugin will randomly fail, especially with a that short random part. Just use a counter.
