### PR TITLE
Let replacer take environment sandbox as well

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,6 +82,6 @@ Plugin.prototype.parse = function (state, silent) {
 }
 
 Plugin.prototype.render = function (tokens, id, options, env) {
-  return this.replacer(tokens[id].meta.match, stuff)
+  return this.replacer(tokens[id].meta.match, stuff, env)
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,8 @@ console.log(
     .use(require('../')(
       /@(\w+)/,
 
-      function (match, utils) {
+      function (match, utils, env) {
+        if (!env.userExists(match[1])) return '@' + match[1];
         var url = 'http://example.org/u/' + match[1]
 
         return '<a href="' + utils.escape(url) + '">'
@@ -12,5 +13,12 @@ console.log(
              + '</a>'
       }
     ))
-    .render("hello @user")
+    .render(
+      "hello @user and @user2",
+      {
+        userExists: function (u) {
+          return u === "user"
+        }
+      }
+    )
 )


### PR DESCRIPTION
This patch makes replacer to take `env`, an environment sandbox.  This is quite useful for checking the link is appropriate at runtime.  For the detailed description of `env`, see also the [reference for `MarkdownIt.parse()`][1]:

> `env` is used to pass data between "distributed" rules and return additional metadata like reference info, needed for the renderer. It also can be used to inject data in specific cases. Usually, you will be ok to pass `{}`, and then pass updated object to renderer.

[1]: https://markdown-it.github.io/markdown-it/#MarkdownIt.parse